### PR TITLE
Feature/api login auth excep

### DIFF
--- a/api/src/main/java/com/tmarket/ApiApplication.java
+++ b/api/src/main/java/com/tmarket/ApiApplication.java
@@ -1,28 +1,21 @@
 package com.tmarket;
 
-import com.tmarket.controller.member.MemberController;
+import com.tmarket.model.conf.PropertyConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
-import org.springframework.context.annotation.ComponentScan;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 
 @SpringBootApplication(exclude = {DataSourceAutoConfiguration.class })
-@ComponentScan(basePackages= {"com.tmarket.*", "com.tmarket.controller.*", "com.tmarket.service.*"})
+@EnableConfigurationProperties(PropertyConfig.class)
 public class ApiApplication {
-    private static final Logger logger = LoggerFactory.getLogger(MemberController.class);
+    private static final Logger logger = LoggerFactory.getLogger(ApiApplication.class);
 
     public static void main(String[] args) {
         SpringApplication.run(ApiApplication.class, args);
-
-        logger.info("===================================================");
-        logger.info("===================================================");
-        logger.info("===================================================");
         logger.info("========thunder-market 에 오신것을 환영합니다.========");
-        logger.info("===================================================");
-        logger.info("===================================================");
-        logger.info("===================================================");
     }
 }

--- a/api/src/main/java/com/tmarket/controller/member/MemberController.java
+++ b/api/src/main/java/com/tmarket/controller/member/MemberController.java
@@ -1,18 +1,16 @@
 package com.tmarket.controller.member;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tmarket.exception.UnauthorizedException;
 import com.tmarket.model.member.LoginDTO;
 import com.tmarket.model.member.LoginDTO.LoginRequest;
 import com.tmarket.model.member.LoginDTO.LoginResponse;
 import com.tmarket.service.authentication.AuthenticationService;
-import com.tmarket.service.authentication.UnauthorizedException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -25,51 +23,31 @@ public class MemberController {
 
     private static final Logger logger = LoggerFactory.getLogger(MemberController.class);
 
-    private ObjectMapper objectMapper;
-
     private AuthenticationService authenticationService;
 
     @Autowired
     public MemberController(
-            AuthenticationService authenticationService,
-            ObjectMapper objectMapper) {
+            AuthenticationService authenticationService) {
         this.authenticationService = authenticationService;
-        this.objectMapper = objectMapper;
     }
 
     @PostMapping("/login")
-    public ResponseEntity<LoginResponse> loginUser(@RequestBody LoginRequest request,
-                               HttpServletRequest httpServletRequest, HttpSession session) throws RuntimeException, JsonProcessingException {
-        logger.info("로그인 요청: {}", objectMapper.writeValueAsString(request));
+    public ResponseEntity<LoginResponse> loginUser(
+            @RequestBody LoginRequest request,
+            HttpServletRequest httpServletRequest,
+            HttpSession session) throws RuntimeException, IllegalArgumentException, UnauthorizedException {
 
-        try {
-            // Authentication Layer로 사용자 인증 위임
-            LoginDTO.LoginResponse response = authenticationService.authenticateUser(request);
-            return ResponseEntity.ok(response);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(new LoginDTO.LoginResponse(e.getMessage(), null, null, null));
-        } catch (UnauthorizedException e) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(new LoginDTO.LoginResponse(e.getMessage(), null, null, null));
-        }
+        logger.info("로그인 요청: {}", request.toString());
+
+        LoginDTO.LoginResponse response = authenticationService.authenticateUser(request);
+        return ResponseEntity.ok(response);
     }
 
     @PostMapping("/logout")
     public ResponseEntity<LoginResponse> logoutUser(@RequestBody LoginRequest request,
                                                    HttpServletRequest httpServletRequest, HttpSession session) throws RuntimeException, JsonProcessingException {
-        logger.info("로그인 요청: {}", objectMapper.writeValueAsString(request));
+        logger.info("로그인 요청: {}", request.getClass());
 
-        try {
-            // Authentication Layer로 사용자 인증 위임
-            LoginDTO.LoginResponse response = authenticationService.authenticateUser(request);
-            return ResponseEntity.ok(response);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(new LoginDTO.LoginResponse(e.getMessage(), null, null, null));
-        } catch (UnauthorizedException e) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(new LoginDTO.LoginResponse(e.getMessage(), null, null, null));
-        }
+        return null;
     }
 }

--- a/api/src/main/java/com/tmarket/exception/GlobalExceptionHandler.java
+++ b/api/src/main/java/com/tmarket/exception/GlobalExceptionHandler.java
@@ -1,0 +1,52 @@
+package com.tmarket.exception;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+// @ControllerAdvice : 전역 예외 핸들러 매핑 클래스
+// basePackages : 특정 패키지 지정
+// assignableTypes  : 특정 클래스 지정
+@ControllerAdvice(basePackages = {"com.tmarket.controller"})
+public class GlobalExceptionHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+    // 401 Unauthorized 예외 처리 (UnauthorizedException)
+    @ExceptionHandler({UserNotFoundException.class, IncorrectPasswordException.class})
+    public ResponseEntity<String> handleUnauthorizedException(UnauthorizedException ex) {
+        logger.error("인증 실패: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ex.getMessage());
+    }
+
+    // 400 Bad Request 예외 처리 (InvalidRequestException)
+    @ExceptionHandler(InvalidRequestException.class)
+    public ResponseEntity<String> handleInvalidRequestException(InvalidRequestException ex) {
+        logger.error("잘못된 요청: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+    }
+
+    // 404 Not Found 예외 처리 (ResourceNotFoundException)
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<String> handleResourceNotFoundException(ResourceNotFoundException ex) {
+        logger.error("리소스를 찾을 수 없음: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
+    }
+
+    // 500 Internal Server Error 예외 처리  (InternalServerException)
+    @ExceptionHandler(InternalServerException.class)
+    public ResponseEntity<String> handleInternalServerException(InternalServerException ex) {
+        logger.error("서버 내부 오류 발생: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("서버 내부 오류가 발생했습니다.");
+    }
+
+    // 500 기타 모든 예외 처리 (Exception)
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<String> handleGlobalException(Exception ex) {
+        logger.error("예상치 못한 서버 오류 발생: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("예상치 못한 오류가 발생했습니다.");
+    }
+}

--- a/api/src/main/java/com/tmarket/exception/IncorrectPasswordException.java
+++ b/api/src/main/java/com/tmarket/exception/IncorrectPasswordException.java
@@ -1,0 +1,7 @@
+package com.tmarket.exception;
+
+public class IncorrectPasswordException extends UnauthorizedException {
+    public IncorrectPasswordException(String message) {
+        super(message);
+    }
+}

--- a/api/src/main/java/com/tmarket/exception/InternalServerException.java
+++ b/api/src/main/java/com/tmarket/exception/InternalServerException.java
@@ -1,0 +1,12 @@
+package com.tmarket.exception;
+
+import lombok.Getter;
+
+// 내부 서버 오류
+@Getter
+public class InternalServerException extends RuntimeException {
+
+    public InternalServerException(String message) {
+        super(message);
+    }
+}

--- a/api/src/main/java/com/tmarket/exception/InvalidRequestException.java
+++ b/api/src/main/java/com/tmarket/exception/InvalidRequestException.java
@@ -1,0 +1,12 @@
+package com.tmarket.exception;
+
+import lombok.Getter;
+
+// 잘못된 요청 예외
+@Getter
+public class InvalidRequestException extends RuntimeException {
+
+    public InvalidRequestException(String message) {
+        super(message);
+    }
+}

--- a/api/src/main/java/com/tmarket/exception/ResourceNotFoundException.java
+++ b/api/src/main/java/com/tmarket/exception/ResourceNotFoundException.java
@@ -1,0 +1,12 @@
+package com.tmarket.exception;
+
+import lombok.Getter;
+
+// 리소스 없음 예외
+@Getter
+public class ResourceNotFoundException extends RuntimeException {
+
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/api/src/main/java/com/tmarket/exception/UnauthorizedException.java
+++ b/api/src/main/java/com/tmarket/exception/UnauthorizedException.java
@@ -1,8 +1,8 @@
-package com.tmarket.service.authentication;
+package com.tmarket.exception;
 
+// 인증실패에 대한 전역 예외 처리
 public class UnauthorizedException extends RuntimeException {
 
-    // 인증실패에 대한 전역 예외 처리
     public UnauthorizedException(String message) {
         super(message);
     }

--- a/api/src/main/java/com/tmarket/exception/UserNotFoundException.java
+++ b/api/src/main/java/com/tmarket/exception/UserNotFoundException.java
@@ -1,0 +1,7 @@
+package com.tmarket.exception;
+
+public class UserNotFoundException extends UnauthorizedException {
+    public UserNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/api/src/main/java/com/tmarket/model/conf/PropertyConfig.java
+++ b/api/src/main/java/com/tmarket/model/conf/PropertyConfig.java
@@ -1,0 +1,17 @@
+package com.tmarket.model.conf;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component // 빈으로 등록
+@ConfigurationProperties(prefix = "property-test-config")  // prefix 설정 from application.yml
+// propertyConfig시 Prefix must be in canonical form에러 발생 : 네이밍 표준 형식을 사용해야 한다.
+// ex) myApp (X) → my-app (O), myCommonProperties (X) → my-common-properties (O)
+
+//@Component // 빈으로 등록 -> @EnableConfigurationProperties(PropertyConfig.class) 으로 대체
+@Data   // @Setter 필요
+public class PropertyConfig {
+    private String authLogintUrl;
+    private String port;
+}

--- a/api/src/main/java/com/tmarket/model/member/LoginDTO.java
+++ b/api/src/main/java/com/tmarket/model/member/LoginDTO.java
@@ -2,24 +2,28 @@ package com.tmarket.model.member;
 
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 
 import java.util.Date;
 
 public class LoginDTO {
     // 기본 생성자를 private으로 선언하여 인스턴스 생성 방지
     // 정적 중첩 클래스만을 포함하고 있으므로 인스턴스를 생성할 필요가 없음
-    private LoginDTO() {
-        throw new UnsupportedOperationException("유틸리티 클래스이므로 인스턴스를 생성할 수 없습니다.");
-    }
+    // 250114 추가 throw new UnsupportedOperationException("유틸리티 클래스이므로 인스턴스를 생성할 수 없습니다.");
+    // 은 유틸리티 클래스에 대한 예외이지만, 이 클래스는 유틸리티 클래스가 아니고 private이 이미 그 기능을
+    // 수행하고 있기때문에 불필요하여 삭제함
+    private LoginDTO() {}
 
     @Getter
     @Setter
+    @ToString
     public static class LoginRequest {
         private String email;
         private String password;
     }
 
     @Getter
+    @ToString
     public static class LoginResponse {
         private String token;
         private String name;

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -9,3 +9,7 @@ spring:
       host: localhost       # Redis 서버의 호스트명
       port: 6379            # Redis 서버의 포트 번호
       timeout: 2000ms       # Redis 연결 타임아웃
+
+property-test-config:
+  authLogintUrl: /auth/login
+  port: 8080

--- a/api/src/test/java/com/tmarket/ApiApplicationTest.java
+++ b/api/src/test/java/com/tmarket/ApiApplicationTest.java
@@ -1,9 +1,12 @@
 package com.tmarket;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT) // 내장 Ramdom Port 사용
+// 통합 테스트 코드끼리 연동이 되는지 확인하기 위해 MemberControllerIntegrationTest에서
+// @SpringBootTest을 지우고 ApiApplicationTest의 @SpringBootTest에 영향을 받는지 테스트함
+// 통합테스트 코드끼리는 서로 영향을 줄 수 없다는 것을 알게되었음
+// 이 클래스에서 @SpringBootTest 어노테이션은 어디상 필요없으나 기록용도로 보존함
+// @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class ApiApplicationTest {
 
     @Test // 모든 컨텍스트가 로드되어있는지 테스트해주는 기본 생성 어노테이션

--- a/api/src/test/java/com/tmarket/controller/member/MemberControllerIntegrationTest.java
+++ b/api/src/test/java/com/tmarket/controller/member/MemberControllerIntegrationTest.java
@@ -1,13 +1,12 @@
 package com.tmarket.controller.member;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tmarket.model.conf.PropertyConfig;
 import com.tmarket.model.member.LoginDTO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.HttpStatus;
@@ -15,18 +14,14 @@ import org.springframework.http.ResponseEntity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest(
-        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, // 내장 Random Port 사용
-        properties = {
-                "propertyTest.value=/auth/login"
-        })
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT) // 내장 Random Port 사용
 public class MemberControllerIntegrationTest {
 
     @Autowired  // TestRestTemplate 사용
     private TestRestTemplate restTemplate;
 
-    @Value("${propertyTest.value}")
-    private String propertyValue;
+    @Autowired // @Value 대신 @ConfigurationProperties 사용
+    private PropertyConfig propertyConfig;
 
     // ResponseEntity객체가 @ResponseBody로 직렬화된 JSON 데이터를 반환하는 것과 달리
     // 테스트코드에서는 response 출력시 응답객체대신 객체의 메모리가 참조되고 있다.
@@ -40,20 +35,21 @@ public class MemberControllerIntegrationTest {
     // 여기서는 ObjectMapper의 사용법을 익히기 위해 후자의 방식을 채택하였다.
     //  => 로그인 실패 응답: {"token":"아이디 혹은 이메일이 유효하지 않습니다.","name":null,"email":null,"lastDt":null}
     //  => 로그인 성공 응답: {"token":"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJjYmtkZXZlbG9wNTdAZ21haWwuY29tIiwibmFtZSI6Iuy1nOuzkeq2jCIsImV4cCI6MTczNjY4NDI4NX0.F1mLoR2xfEirG9XNQ1tEZ-zNH1d5BL6K0DarYx8whb4","name":"최병권","email":"cbkdevelop57@gmail.com","lastDt":"2025-01-11T12:18:05.733+00:00"}
-    @Autowired // Jackson ObjectMapper 주입
-    private ObjectMapper objectMapper;
+    // @Autowired // Jackson ObjectMapper 주입
+//    private ObjectMapper objectMapper;
+    // => 단순 로깅 전략으로 ObjectMapper는 너무 무겁다는 의견이 나와 toString으로 교체(250120)
 
     private String baseUrl;
 
     @BeforeEach // 테스트 초기화
     public void setup() {
-        System.out.println("propertyTest.value=" + propertyValue);
-        baseUrl = propertyValue;
+        System.out.println("propertyConfig.getDefaultUrl() =" + propertyConfig.getAuthLogintUrl());
+        baseUrl = propertyConfig.getAuthLogintUrl();
     }
 
     @Test
     @DisplayName("1. 로그인 실패: 올바르지 않은 아이디와 패스워드")
-    void loginFailTest() throws JsonProcessingException {
+    void loginFailTest() {
         // given(테스트 조건 준비)
         LoginDTO.LoginRequest invalidRequest = new LoginDTO.LoginRequest();
         invalidRequest.setEmail("invalidEmail@gmail.com");
@@ -62,7 +58,8 @@ public class MemberControllerIntegrationTest {
 
         // when(테스트 액션 실행)
         ResponseEntity<LoginDTO.LoginResponse> response = restTemplate.postForEntity(baseUrl, invalidRequest, LoginDTO.LoginResponse.class);
-        System.out.println("로그인 실패 응답: " + objectMapper.writeValueAsString(response.getBody()));
+        // 개인 테스트용 코드들은 지우는 것을 추천 (추후 테스트 코드에서는 삭제하기로 함) - 이 코드는 이에 대한 기록을 위해 보존
+//        System.out.println("로그인 실패 응답: " + objectMapper.writeValueAsString(response.getBody()));
 
         // then(테스트 결과 검증)
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
@@ -75,7 +72,7 @@ public class MemberControllerIntegrationTest {
 
     @Test
     @DisplayName("2. 로그인 성공: 올바른 아이디와 패스워드")
-    void loginSuccessTest() throws JsonProcessingException {
+    void loginSuccessTest() {
         // given
         LoginDTO.LoginRequest validRequest = new LoginDTO.LoginRequest();
         validRequest.setEmail("cbkdevelop57@gmail.com");
@@ -83,7 +80,7 @@ public class MemberControllerIntegrationTest {
 
         // when
         ResponseEntity<LoginDTO.LoginResponse> response = restTemplate.postForEntity(baseUrl, validRequest, LoginDTO.LoginResponse.class);
-        System.out.println("로그인 성공 응답: " + objectMapper.writeValueAsString(response.getBody()));
+//        System.out.println("로그인 성공 응답: " + objectMapper.writeValueAsString(response.getBody()));
 
         // then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -107,7 +104,8 @@ public class MemberControllerIntegrationTest {
                 restTemplate.postForEntity(baseUrl, didNotInputEmailValueRequest, LoginDTO.LoginResponse.class);
 
         // JSON 응답 출력
-        System.out.println("이메일 누락 응답: " + objectMapper.writeValueAsString(response.getBody()));
+//        System.out.println("이메일 누락 응답: " + objectMapper.writeValueAsString(response.getBody()));
+        System.out.println("이메일 누락 응답: " + response.getBody());
 
         // then(테스트 결과 검증)
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
@@ -131,7 +129,8 @@ public class MemberControllerIntegrationTest {
                 restTemplate.postForEntity(baseUrl, didNotInputPasswordValueRequest, LoginDTO.LoginResponse.class);
 
         // JSON 응답 출력
-        System.out.println("패스워드 누락 응답: " + objectMapper.writeValueAsString(response.getBody()));
+        System.out.println("패스워드 누락 응답: " + response.toString()); // ResponseEntity 객체의 기본 toString() 출력
+        System.out.println("패스워드 누락 응답: " + response.getBody());  // 실제 응답객체(LoginResponse)의 override된 toString() 출력
 
         // then(테스트 결과 검증)
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);


### PR DESCRIPTION
1. @componentscan 불필요한 중복 설정 삭제
2. ObjectMapper를 toString로 변경 (단순 로깅 용도로 ObjectMapper는 너무 과하다는 의견 반영)
3. 기존 개별로 처리하던 예외를 Exception패키지를 만들고, GlobalExceptionHandler 에서 전역으로 관리하도록 설정)
4. 사용자 로그인 인증처리시 isEmpty로 공백을 검증
5. UnauthorizedException 예외처리를 UserNotFoundException, IncorrectPasswordException으로 세분화